### PR TITLE
Feat/apply inline style overrides on add

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -42,14 +42,14 @@ class RichEditor extends React.Component {
     return this.updateEditorState(newEditorState);
   };
 
-  addFontSize = val => () => {
-    const newEditorState = styles.fontSize.add(this.state.editorState, val);
-
-    return this.updateEditorState(newEditorState);
-  };
-
   toggleColor = color => {
     const newEditorState = styles.color.toggle(this.state.editorState, color);
+
+    return this.updateEditorState(newEditorState, this.focusEditor);
+  };
+
+  addColor = color => {
+    const newEditorState = styles.color.add(this.state.editorState, color);
 
     return this.updateEditorState(newEditorState, this.focusEditor);
   };
@@ -78,7 +78,22 @@ class RichEditor extends React.Component {
             </Button>
           </div>
           <div>
-            <h2>Font Size</h2>
+            <h2>Add Colors</h2>
+            <Button
+              style={{ background: styles.color.current(this.state.editorState) === 'red' ? 'red' : null }}
+              onClick={() => this.addColor('red')}
+            >
+              red
+            </Button>
+            <Button
+              style={{ background: styles.color.current(this.state.editorState) === 'blue' ? 'blue' : null }}
+              onClick={() => this.addColor('blue')}
+            >
+              blue
+            </Button>
+          </div>
+          <div>
+            <h2>Toggle font Size</h2>
             <Button
               onClick={this.removeFontSize}
             >
@@ -107,7 +122,7 @@ class RichEditor extends React.Component {
         </div>
         <div style={{ flex: '0 0 25%' }}>
           <h2>Exported To HTML</h2>
-          <div dangerouslySetInnerHTML={{ __html: html }}/>
+          <div dangerouslySetInnerHTML={{ __html: html }} />
         </div>
         <div style={{ flex: '0 0 25%' }}>
           <h2>ContentState</h2>

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,6 @@ const toggleInlineStyleOverride = (prefix, style, editorState) => {
   // variants of the same prefix.
   const newStyles = filterOverrideStyles(prefix, currentStyle);
 
-  // We check the original override styles
   const styleOverride = currentStyle.has(style)
     ? newStyles.remove(style)
     : newStyles.add(style);

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ const addInlineStyleOverride = (prefix, style, editorState) => {
   // We remove styles with the prefix from the OrderedSet to avoid having
   // variants of the same prefix.
   const newStyles = filterOverrideStyles(prefix, currentStyle);
-  
+
   return EditorState.setInlineStyleOverride(editorState, newStyles.add(style));
 };
 

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -34,13 +34,13 @@ describe('createStyles', () => {
     expect(exporter).to.exist;
   });
   it('should return an empty object if no styles are passed', () => {
-    const { styles } = createStyles();
-    expect(styles).to.deep.equal({});
+    const { styles: createdStyles } = createStyles();
+    expect(createdStyles).to.deep.equal({});
   });
 });
 
 describe('add()', () => {
-  const config = ['color'];
+  const config = ['color', 'font-size'];
   const { styles } = createStyles(config);
   it('should add a custom inline style on a non-collapsed selection', () => {
     const editorState = new Raw()
@@ -72,6 +72,35 @@ describe('add()', () => {
         length: 5,
         offset: 0,
       }]);
+  });
+  it('should add a customStyleOverride when adding style to a collapsed selection', () => {
+    const editorState = new Raw()
+      .addBlock('block 1')
+      .collapse(3)
+      .toEditorState();
+    const newEditorState = styles.color.add(editorState, 'red');
+    const override = newEditorState.getInlineStyleOverride();
+    expect(override.toJS()).to.deep.equal(OrderedSet(['CUSTOM_COLOR_red']).toJS());
+  });
+  it('should add a 2 of the same prefixed styles to the same collapsed selection and show only the latest style', () => {
+    const editorState = new Raw()
+      .addBlock('block 1')
+      .collapse(3)
+      .toEditorState();
+    const newEditorState = styles.color.add(editorState, 'red');
+    const newEditorState2 = styles.color.add(newEditorState, 'blue');
+    const override = newEditorState2.getInlineStyleOverride();
+    expect(override.toJS()).to.deep.equal(OrderedSet(['CUSTOM_COLOR_blue']).toJS());
+  });
+  it('should add 2 of the different prefixed styles to the same collapsed selection and show both', () => {
+    const editorState = new Raw()
+      .addBlock('block 1')
+      .collapse(3)
+      .toEditorState();
+    const newEditorState = styles.color.add(editorState, 'red');
+    const newEditorState2 = styles.fontSize.add(newEditorState, '12px');
+    const override = newEditorState2.getInlineStyleOverride();
+    expect(override.toJS()).to.deep.equal(OrderedSet(['CUSTOM_COLOR_red', 'CUSTOM_FONT_SIZE_12px']).toJS());
   });
 });
 
@@ -259,7 +288,7 @@ describe('exporter()', () => {
       BOLD: {
         style: {
           fontWeight: 'bold',
-        }
+        },
       },
       CUSTOM_BACKGROUND_COLOR_green: {
         style: {


### PR DESCRIPTION
## What does this PR do?

This PR adds the inlineStyleOverrides to a collapsed selection when using the .add() fn.
![test](https://user-images.githubusercontent.com/7534346/34925897-479113c0-f97a-11e7-894e-82867675ecb7.gif)
