### PR TITLE
Css vendor prefixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,15 @@
-import { EditorState, Modifier, convertToRaw, DefaultDraftInlineStyle } from 'draft-js';
-import { Map } from 'immutable';
-import camelCase from 'lodash.camelcase';
-import snakeCase from 'lodash.snakecase';
+import {
+  EditorState,
+  Modifier,
+  convertToRaw,
+  DefaultDraftInlineStyle
+} from 'draft-js'
+import { Map } from 'immutable'
+import snakeCase from 'lodash.snakecase'
 
-const DEFAULT_PREFIX = 'CUSTOM_';
+import { toReactCssCase } from './to-react-css-case'
+
+const DEFAULT_PREFIX = 'CUSTOM_'
 
 // This functionality has been taken from draft-js and modified for re-usability purposes.
 // Maps over the selected characters, and applies a function to each character.
@@ -142,7 +148,7 @@ const styleFn = (prefix, cssProp) => style => {
   const value = style.filter(val => val.startsWith(prefix)).first();
   if (value) {
     const newVal = value.replace(prefix, '');
-    return { [camelCase(cssProp)]: newVal };
+    return { [toReactCssCase(cssProp)]: newVal };
   }
   return {};
 };
@@ -160,7 +166,7 @@ const currentStyle = prefix => editorState => {
 
 export const createCustomStyles = (prefix, conf) => {
   return conf.reduce((acc, prop) => {
-    const camelCased = camelCase(prop);
+    const camelCased = toReactCssCase(prop);
     const newPrefix = `${prefix}${snakeCase(prop).toUpperCase()}_`;
     const copy = { ...acc };
     copy[camelCased] = {
@@ -226,7 +232,7 @@ export const createInlineStyleExportObject = (prefix, customStyleMap) => (acc, s
   const inlineStyle = {
     [style]: {
       style: {
-        [camelCase(css)]: value,
+        [toReactCssCase(css)]: value,
       },
     },
   };

--- a/src/to-react-css-case.js
+++ b/src/to-react-css-case.js
@@ -9,7 +9,6 @@ const isVendorCssProps = (cssProp) => {
 }
 
 export const toReactCssCase = (string) => {
-  console.log(string)
   const camelCased = camelCase(string)
 
   if (isVendorCssProps(string)) return camelCased.charAt(0).toUpperCase() + camelCased.slice(1)

--- a/src/to-react-css-case.js
+++ b/src/to-react-css-case.js
@@ -1,0 +1,18 @@
+import camelCase from 'lodash.camelcase'
+
+const vendors = ['webkit', 'moz', 'ms', 'o']
+const vendorsPrefixesRegexps = vendors.map(vendor => RegExp(`^(\-${vendor}\-|${vendor}_)`)) // for example /^(\-webkit\-|webkit_)/
+
+const isVendorCssProps = (cssProp) => {
+  const lowerCased = cssProp.toLowerCase()
+  return vendorsPrefixesRegexps.some(regex => regex.test(lowerCased))
+}
+
+export const toReactCssCase = (string) => {
+  console.log(string)
+  const camelCased = camelCase(string)
+
+  if (isVendorCssProps(string)) return camelCased.charAt(0).toUpperCase() + camelCased.slice(1)
+
+  return camelCased
+}


### PR DESCRIPTION
## Pull Requests

This PR addresses the issue of supporting vendor prefixed styles. Inline styles with vendor prefixes are handled in Pascal case instead of camel case. Related issue #15 
